### PR TITLE
Add todo script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ python src/calculator.py 3 5 -o add
 
 No additional dependencies are required since the script only uses Python's standard library.
 
-## Managing your todo list
+## Todo List
 
 A small helper script `src/todo.py` lets you keep track of tasks in a file called `tasks.txt` at the repository root.
 Use it to add new items or display the current list:

--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ python src/calculator.py 3 5 -o add
 ```
 
 No additional dependencies are required since the script only uses Python's standard library.
+
+## Managing your todo list
+
+A small helper script `src/todo.py` lets you keep track of tasks in a file called `tasks.txt` at the repository root.
+Use it to add new items or display the current list:
+
+```bash
+python src/todo.py add "Buy groceries"
+python src/todo.py list
+```

--- a/src/todo.py
+++ b/src/todo.py
@@ -1,0 +1,50 @@
+# Simple command-line todo list manager
+
+import argparse
+from pathlib import Path
+
+TASKS_FILE = Path(__file__).resolve().parent.parent / "tasks.txt"
+
+
+def add_task(description: str) -> None:
+    """Append a task description to the tasks file."""
+    with open(TASKS_FILE, "a", encoding="utf-8") as f:
+        f.write(description.strip() + "\n")
+
+
+def list_tasks() -> list[str]:
+    """Return the list of tasks from the tasks file."""
+    if not TASKS_FILE.exists():
+        return []
+    with open(TASKS_FILE, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def main() -> None:
+    """Handle command-line arguments for adding and listing tasks."""
+    parser = argparse.ArgumentParser(description="Simple todo list manager")
+    subparsers = parser.add_subparsers(dest="command")
+
+    add_parser = subparsers.add_parser("add", help="Add a new task")
+    add_parser.add_argument("description", help="task description")
+
+    subparsers.add_parser("list", help="List existing tasks")
+
+    args = parser.parse_args()
+
+    if args.command == "add":
+        add_task(args.description)
+        print("Task added.")
+    elif args.command == "list":
+        tasks = list_tasks()
+        if not tasks:
+            print("No tasks found.")
+        else:
+            for idx, task in enumerate(tasks, 1):
+                print(f"{idx}. {task}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/todo.py
+++ b/src/todo.py
@@ -1,7 +1,9 @@
-# Simple command-line todo list manager
+#!/usr/bin/env python3
+"""Simple command-line todo list manager."""
 
 import argparse
 from pathlib import Path
+from typing import List
 
 TASKS_FILE = Path(__file__).resolve().parent.parent / "tasks.txt"
 
@@ -12,7 +14,7 @@ def add_task(description: str) -> None:
         f.write(description.strip() + "\n")
 
 
-def list_tasks() -> list[str]:
+def list_tasks() -> List[str]:
     """Return the list of tasks from the tasks file."""
     if not TASKS_FILE.exists():
         return []


### PR DESCRIPTION
## Summary
- add `src/todo.py` for a simple command-line todo list
- document todo usage in the README

## Testing
- `python -m py_compile src/calculator.py src/todo.py`
- `python src/todo.py add "Another task"`
- `python src/todo.py list`
- `python src/todo.py list` after removing `tasks.txt`


------
https://chatgpt.com/codex/tasks/task_e_6859e8754ccc83339d55c7b3d7a04231