### PR TITLE
Switch weight units from kilograms to pounds throughout system

### DIFF
--- a/kickboxing-tournament/backend/app/models/db_models.py
+++ b/kickboxing-tournament/backend/app/models/db_models.py
@@ -62,7 +62,7 @@ class Tournament(Base):
     bout_duration_minutes = Column(Integer, default=3)
     break_duration_minutes = Column(Integer, default=2)
     buffer_minutes = Column(Integer, default=1)
-    weighin_tolerance_kg = Column(Float, default=0.5)
+    weighin_tolerance_lbs = Column(Float, default=1.1)
     substitution_cutoff_round = Column(Integer, default=1)  # After this round, no subs
     no_show_policy = Column(Enum(NoShowPolicy), default=NoShowPolicy.WALKOVER)
     weight_presets = Column(JSON, nullable=True)  # Custom weight class presets
@@ -156,10 +156,12 @@ class Registration(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     tournament_id = Column(Integer, ForeignKey("tournaments.id", ondelete="CASCADE"), nullable=False)
-    division_id = Column(Integer, ForeignKey("divisions.id", ondelete="CASCADE"), nullable=False)
+    # division_id is auto-assigned from declared_weight; nullable so a registration
+    # can be saved even if no matching division exists yet.
+    division_id = Column(Integer, ForeignKey("divisions.id", ondelete="SET NULL"), nullable=True)
     full_name = Column(String(200), nullable=False)
     email = Column(String(200), nullable=False)
-    declared_weight = Column(Float, nullable=True)
+    declared_weight = Column(Float, nullable=False)
     gym_team = Column(String(200), nullable=True)
     phone = Column(String(50), nullable=True)
     age = Column(Integer, nullable=True)

--- a/kickboxing-tournament/backend/app/models/schemas.py
+++ b/kickboxing-tournament/backend/app/models/schemas.py
@@ -21,8 +21,8 @@ class TokenResponse(BaseModel):
 
 class WeightPreset(BaseModel):
     name: str
-    min_kg: Optional[float] = None
-    max_kg: Optional[float] = None
+    min_lbs: Optional[float] = None
+    max_lbs: Optional[float] = None
 
 
 class TournamentCreate(BaseModel):
@@ -34,7 +34,7 @@ class TournamentCreate(BaseModel):
     bout_duration_minutes: int = Field(ge=1, le=30, default=3)
     break_duration_minutes: int = Field(ge=0, le=30, default=2)
     buffer_minutes: int = Field(ge=0, le=15, default=1)
-    weighin_tolerance_kg: float = Field(ge=0, le=5, default=0.5)
+    weighin_tolerance_lbs: float = Field(ge=0, le=11, default=1.1)
     substitution_cutoff_round: int = Field(ge=1, default=1)
     no_show_policy: str = Field(default="walkover")
     weight_presets: Optional[List[WeightPreset]] = None
@@ -50,7 +50,7 @@ class TournamentUpdate(BaseModel):
     bout_duration_minutes: Optional[int] = None
     break_duration_minutes: Optional[int] = None
     buffer_minutes: Optional[int] = None
-    weighin_tolerance_kg: Optional[float] = None
+    weighin_tolerance_lbs: Optional[float] = None
     substitution_cutoff_round: Optional[int] = None
     no_show_policy: Optional[str] = None
     weight_presets: Optional[List[WeightPreset]] = None
@@ -67,7 +67,7 @@ class TournamentResponse(BaseModel):
     bout_duration_minutes: int
     break_duration_minutes: int
     buffer_minutes: int
-    weighin_tolerance_kg: float
+    weighin_tolerance_lbs: float
     substitution_cutoff_round: int
     no_show_policy: str
     weight_presets: Optional[list] = None
@@ -271,11 +271,14 @@ class SyncStatusResponse(BaseModel):
 # --- Registration (self-signup) ---
 
 class RegistrationSubmit(BaseModel):
-    """Public-facing registration form submission."""
+    """Public-facing registration form submission.
+
+    Weight is in pounds (lbs); division is auto-assigned by the system based
+    on the entered weight, so the form does NOT include a division field.
+    """
     full_name: str = Field(min_length=1, max_length=200)
     email: str = Field(min_length=3, max_length=200)
-    division_id: int
-    declared_weight: Optional[float] = None
+    declared_weight: float = Field(gt=0, le=1000, description="Competitor weight in pounds (lbs)")
     gym_team: Optional[str] = Field(default=None, max_length=200)
     phone: str = Field(min_length=1, max_length=50)
     age: Optional[int] = Field(default=None, ge=5, le=99)
@@ -301,7 +304,7 @@ class RegistrationSubmit(BaseModel):
 class RegistrationResponse(BaseModel):
     id: int
     tournament_id: int
-    division_id: int
+    division_id: Optional[int] = None
     full_name: str
     email: str
     declared_weight: Optional[float] = None

--- a/kickboxing-tournament/backend/app/routers/registrations.py
+++ b/kickboxing-tournament/backend/app/routers/registrations.py
@@ -14,6 +14,7 @@ from app.models.db_models import (
 from app.models.schemas import (
     RegistrationSubmit, RegistrationResponse, RegistrationReview
 )
+from app.services.divisions import assign_division
 
 router = APIRouter(prefix="/api/tournaments/{tournament_id}/registrations", tags=["registrations"])
 
@@ -43,7 +44,7 @@ def _send_discord_webhook(registration: Registration, tournament: Tournament, di
                     {"name": "Division", "value": division_name, "inline": True},
                     {"name": "Email", "value": registration.email, "inline": True},
                     {"name": "Gym/Team", "value": registration.gym_team or "N/A", "inline": True},
-                    {"name": "Weight", "value": f"{round(registration.declared_weight * 2.20462)} lbs" if registration.declared_weight else "N/A", "inline": True},
+                    {"name": "Weight", "value": f"{round(registration.declared_weight)} lbs" if registration.declared_weight else "N/A", "inline": True},
                     {"name": "Tournament", "value": tournament.name, "inline": False},
                 ],
                 "footer": {"text": f"Registration #{registration.id} - Pending review"},
@@ -67,16 +68,17 @@ def submit_registration(tournament_id: int, data: RegistrationSubmit,
     if not tournament.registration_open:
         raise HTTPException(400, "Registration is not currently open for this tournament.")
 
-    # Validate division belongs to this tournament
-    division = db.query(Division).filter(
-        Division.id == data.division_id,
-        Division.tournament_id == tournament_id,
-    ).first()
-    if not division:
-        raise HTTPException(400, "Selected division does not exist in this tournament.")
-
     if not data.waiver_agreed:
         raise HTTPException(400, "You must agree to the waiver to register.")
+
+    # Auto-assign division based on declared weight (lbs).
+    division = assign_division(db, tournament_id, data.declared_weight)
+    if not division:
+        raise HTTPException(
+            400,
+            f"No division matches a weight of {data.declared_weight} lbs in this tournament. "
+            "Contact the organizer to add a matching weight class."
+        )
 
     # Duplicate check: same email + same tournament
     existing = db.query(Registration).filter(
@@ -94,7 +96,7 @@ def submit_registration(tournament_id: int, data: RegistrationSubmit,
 
     reg = Registration(
         tournament_id=tournament_id,
-        division_id=data.division_id,
+        division_id=division.id,
         full_name=data.full_name,
         email=data.email,
         declared_weight=data.declared_weight,
@@ -184,13 +186,19 @@ def review_registration(tournament_id: int, registration_id: int,
 
         return _registration_to_response(reg, db)
 
-    # --- Approve: create a Competitor via the same path admin uses ---
-    division = db.query(Division).filter(Division.id == reg.division_id).first()
+    # --- Approve: re-run division auto-assignment from the stored lbs weight,
+    # then create a Competitor in that division.
+    division = assign_division(db, tournament_id, reg.declared_weight)
     if not division:
-        raise HTTPException(400, "Division no longer exists. Cannot approve.")
+        raise HTTPException(
+            400,
+            f"No division matches a weight of {reg.declared_weight} lbs. "
+            "Add a matching weight class before approving."
+        )
+    reg.division_id = division.id
 
     comp = Competitor(
-        division_id=reg.division_id,
+        division_id=division.id,
         full_name=reg.full_name,
         declared_weight=reg.declared_weight,
         gym_team=reg.gym_team,

--- a/kickboxing-tournament/backend/app/routers/tournaments.py
+++ b/kickboxing-tournament/backend/app/routers/tournaments.py
@@ -8,18 +8,7 @@ from app.database import get_db
 from app.auth import require_admin, get_current_role
 from app.models.db_models import Tournament
 from app.models.schemas import TournamentCreate, TournamentUpdate, TournamentResponse
-
-DEFAULT_WEIGHT_PRESETS = [
-    {"name": "Strawweight", "min_kg": None, "max_kg": 52.2},
-    {"name": "Flyweight", "min_kg": 52.2, "max_kg": 56.7},
-    {"name": "Bantamweight", "min_kg": 56.7, "max_kg": 61.2},
-    {"name": "Featherweight", "min_kg": 61.2, "max_kg": 65.8},
-    {"name": "Lightweight", "min_kg": 65.8, "max_kg": 70.3},
-    {"name": "Welterweight", "min_kg": 70.3, "max_kg": 77.1},
-    {"name": "Middleweight", "min_kg": 77.1, "max_kg": 83.9},
-    {"name": "Light Heavyweight", "min_kg": 83.9, "max_kg": 93.0},
-    {"name": "Heavyweight", "min_kg": 93.0, "max_kg": None},
-]
+from app.services.divisions import DEFAULT_WEIGHT_PRESETS_LBS as DEFAULT_WEIGHT_PRESETS
 
 router = APIRouter(prefix="/api/tournaments", tags=["tournaments"])
 
@@ -49,7 +38,7 @@ def create_tournament(data: TournamentCreate, db: Session = Depends(get_db),
         bout_duration_minutes=data.bout_duration_minutes,
         break_duration_minutes=data.break_duration_minutes,
         buffer_minutes=data.buffer_minutes,
-        weighin_tolerance_kg=data.weighin_tolerance_kg,
+        weighin_tolerance_lbs=data.weighin_tolerance_lbs,
         substitution_cutoff_round=data.substitution_cutoff_round,
         no_show_policy=data.no_show_policy,
         weight_presets=([p.model_dump() for p in data.weight_presets]

--- a/kickboxing-tournament/backend/app/services/divisions.py
+++ b/kickboxing-tournament/backend/app/services/divisions.py
@@ -1,0 +1,70 @@
+"""Weight class division definitions and auto-assignment.
+
+Single source of truth for default division thresholds. All weights stored
+and compared in pounds (lbs). Division boundaries are open-low / closed-high:
+a competitor is in division D when (D.min_lbs, D.max_lbs] contains their weight,
+where None min/max means open-ended.
+"""
+
+from typing import Optional, List
+from sqlalchemy.orm import Session
+
+from app.models.db_models import Division
+
+
+# Conversion factor used by the one-time kg -> lbs migration helper.
+KG_TO_LBS = 2.2046226218
+
+
+# Default tournament weight class presets, in pounds.
+# Mirrors the previous kg-based MMA-style preset but expressed in lbs.
+DEFAULT_WEIGHT_PRESETS_LBS = [
+    {"name": "Strawweight", "min_lbs": None, "max_lbs": 115.0},
+    {"name": "Flyweight", "min_lbs": 115.0, "max_lbs": 125.0},
+    {"name": "Bantamweight", "min_lbs": 125.0, "max_lbs": 135.0},
+    {"name": "Featherweight", "min_lbs": 135.0, "max_lbs": 145.0},
+    {"name": "Lightweight", "min_lbs": 145.0, "max_lbs": 155.0},
+    {"name": "Welterweight", "min_lbs": 155.0, "max_lbs": 170.0},
+    {"name": "Middleweight", "min_lbs": 170.0, "max_lbs": 185.0},
+    {"name": "Light Heavyweight", "min_lbs": 185.0, "max_lbs": 205.0},
+    {"name": "Heavyweight", "min_lbs": 205.0, "max_lbs": None},
+]
+
+
+def assign_division(db: Session, tournament_id: int,
+                    weight_lbs: Optional[float],
+                    gender: Optional[str] = None) -> Optional[Division]:
+    """Find the Division (in `tournament_id`) whose lbs range contains weight_lbs.
+
+    Boundary convention: lower exclusive, upper inclusive.
+    A division with min=None matches everyone up to its max; max=None matches
+    everyone above its min. If `gender` is provided, only divisions with a
+    matching gender (or no gender restriction) are considered.
+    Returns None if no division matches.
+    """
+    if weight_lbs is None:
+        return None
+
+    divisions: List[Division] = (
+        db.query(Division)
+        .filter(Division.tournament_id == tournament_id)
+        .all()
+    )
+
+    candidates = []
+    for d in divisions:
+        if gender and d.gender and d.gender != gender:
+            continue
+        lo = d.weight_class_min if d.weight_class_min is not None else float("-inf")
+        hi = d.weight_class_max if d.weight_class_max is not None else float("inf")
+        if lo < weight_lbs <= hi:
+            candidates.append(d)
+
+    if not candidates:
+        return None
+    # Prefer gender-specific match over a generic (no gender) division.
+    if gender:
+        gendered = [c for c in candidates if c.gender == gender]
+        if gendered:
+            return gendered[0]
+    return candidates[0]

--- a/kickboxing-tournament/backend/app/tests/test_registration.py
+++ b/kickboxing-tournament/backend/app/tests/test_registration.py
@@ -52,20 +52,23 @@ def _create_tournament(client, token, registration_open=True):
     return resp.json()["id"]
 
 
-def _create_division(client, token, tid):
-    """Helper: create a division."""
+def _create_division(client, token, tid, name="Lightweight",
+                     weight_class_min=125, weight_class_max=155):
+    """Helper: create a division (weights are pounds)."""
     resp = client.post(f"/api/tournaments/{tid}/divisions", json={
-        "name": "Lightweight", "weight_class_min": 57, "weight_class_max": 70,
+        "name": name,
+        "weight_class_min": weight_class_min,
+        "weight_class_max": weight_class_max,
     }, headers=auth_header(token))
     return resp.json()["id"]
 
 
-def _valid_registration(division_id):
+def _valid_registration(division_id=None):
+    """A registration payload. division_id is ignored (kept for legacy callers)."""
     return {
         "full_name": "Jane Fighter",
         "email": "jane@example.com",
-        "division_id": division_id,
-        "declared_weight": 68.5,
+        "declared_weight": 150.0,
         "gym_team": "Iron Fist MMA",
         "phone": "555-123-4567",
         "waiver_agreed": True,
@@ -91,29 +94,28 @@ class TestRegistrationSubmission:
 
     def test_registration_with_minimal_fields(self, client, admin_token):
         tid = _create_tournament(client, admin_token)
-        did = _create_division(client, admin_token, tid)
+        _create_division(client, admin_token, tid)
 
         resp = client.post(f"/api/tournaments/{tid}/registrations", json={
             "full_name": "Min Fighter",
             "email": "min@example.com",
-            "division_id": did,
+            "declared_weight": 150.0,
             "phone": "555-0000",
             "waiver_agreed": True,
         })
         assert resp.status_code == 200
         data = resp.json()
-        assert data["declared_weight"] is None
+        assert data["declared_weight"] == 150.0
         assert data["gym_team"] is None
 
     def test_registration_with_all_fields(self, client, admin_token):
         tid = _create_tournament(client, admin_token)
-        did = _create_division(client, admin_token, tid)
+        _create_division(client, admin_token, tid)
 
         resp = client.post(f"/api/tournaments/{tid}/registrations", json={
             "full_name": "Full Fighter",
             "email": "full@example.com",
-            "division_id": did,
-            "declared_weight": 69.0,
+            "declared_weight": 152.0,
             "gym_team": "Power Gym",
             "phone": "+1234567890",
             "age": 25,
@@ -131,49 +133,54 @@ class TestRegistrationValidation:
 
     def test_missing_name(self, client, admin_token):
         tid = _create_tournament(client, admin_token)
-        did = _create_division(client, admin_token, tid)
+        _create_division(client, admin_token, tid)
 
         resp = client.post(f"/api/tournaments/{tid}/registrations", json={
             "full_name": "",
             "email": "test@example.com",
-            "division_id": did,
+            "declared_weight": 150.0,
+            "phone": "555-0000",
             "waiver_agreed": True,
         })
         assert resp.status_code == 422
 
     def test_invalid_email(self, client, admin_token):
         tid = _create_tournament(client, admin_token)
-        did = _create_division(client, admin_token, tid)
+        _create_division(client, admin_token, tid)
 
         resp = client.post(f"/api/tournaments/{tid}/registrations", json={
             "full_name": "Test",
             "email": "not-an-email",
-            "division_id": did,
+            "declared_weight": 150.0,
+            "phone": "555-0000",
             "waiver_agreed": True,
         })
         assert resp.status_code == 422
 
     def test_waiver_not_agreed(self, client, admin_token):
         tid = _create_tournament(client, admin_token)
-        did = _create_division(client, admin_token, tid)
+        _create_division(client, admin_token, tid)
 
         resp = client.post(f"/api/tournaments/{tid}/registrations", json={
             "full_name": "Test Fighter",
             "email": "test@example.com",
-            "division_id": did,
+            "declared_weight": 150.0,
             "phone": "555-0000",
             "waiver_agreed": False,
         })
         assert resp.status_code == 400
         assert "waiver" in resp.json()["detail"].lower()
 
-    def test_invalid_division(self, client, admin_token):
+    def test_no_matching_division(self, client, admin_token):
+        """Weight that falls outside any defined division is rejected."""
         tid = _create_tournament(client, admin_token)
+        # Only a 125-155 lb division.
+        _create_division(client, admin_token, tid)
 
         resp = client.post(f"/api/tournaments/{tid}/registrations", json={
             "full_name": "Test Fighter",
             "email": "test@example.com",
-            "division_id": 99999,
+            "declared_weight": 250.0,
             "phone": "555-0000",
             "waiver_agreed": True,
         })
@@ -182,12 +189,25 @@ class TestRegistrationValidation:
 
     def test_missing_phone(self, client, admin_token):
         tid = _create_tournament(client, admin_token)
-        did = _create_division(client, admin_token, tid)
+        _create_division(client, admin_token, tid)
 
         resp = client.post(f"/api/tournaments/{tid}/registrations", json={
             "full_name": "Test Fighter",
             "email": "test@example.com",
-            "division_id": did,
+            "declared_weight": 150.0,
+            "waiver_agreed": True,
+        })
+        assert resp.status_code == 422
+
+    def test_missing_weight(self, client, admin_token):
+        """Weight (lbs) is required for division auto-assignment."""
+        tid = _create_tournament(client, admin_token)
+        _create_division(client, admin_token, tid)
+
+        resp = client.post(f"/api/tournaments/{tid}/registrations", json={
+            "full_name": "Test Fighter",
+            "email": "test@example.com",
+            "phone": "555-0000",
             "waiver_agreed": True,
         })
         assert resp.status_code == 422
@@ -196,7 +216,7 @@ class TestRegistrationValidation:
         resp = client.post("/api/tournaments/99999/registrations", json={
             "full_name": "Test",
             "email": "test@example.com",
-            "division_id": 1,
+            "declared_weight": 150.0,
             "phone": "555-0000",
             "waiver_agreed": True,
         })
@@ -300,7 +320,7 @@ class TestAdminApproval:
         # Verify the competitor has correct data
         comp = next(c for c in comps if c["full_name"] == "Jane Fighter")
         assert comp["email"] == "jane@example.com"
-        assert comp["declared_weight"] == 68.5
+        assert comp["declared_weight"] == 150.0
         assert comp["gym_team"] == "Iron Fist MMA"
         assert comp["status"] == "active"
 
@@ -428,6 +448,116 @@ class TestStatusCheck:
 
         resp = client.get(f"/api/tournaments/{tid}/registrations/check?email=JANE@example.com")
         assert resp.status_code == 200
+
+
+class TestDivisionAutoAssignment:
+    """Verify the registration form auto-assigns the division from the lbs weight."""
+
+    def test_weight_inside_range_assigned(self, client, admin_token):
+        tid = _create_tournament(client, admin_token)
+        # Lightweight: (125, 155]
+        light_id = _create_division(client, admin_token, tid, "Lightweight", 125, 155)
+        _create_division(client, admin_token, tid, "Welterweight", 155, 170)
+
+        reg = _valid_registration()
+        reg["declared_weight"] = 150.0
+        resp = client.post(f"/api/tournaments/{tid}/registrations", json=reg)
+        assert resp.status_code == 200
+        assert resp.json()["division_id"] == light_id
+        assert resp.json()["division_name"] == "Lightweight"
+
+    def test_weight_at_upper_boundary_assigned_lower_division(self, client, admin_token):
+        """Boundary convention: upper bound is inclusive — 155.0 lbs is Lightweight."""
+        tid = _create_tournament(client, admin_token)
+        light_id = _create_division(client, admin_token, tid, "Lightweight", 125, 155)
+        _create_division(client, admin_token, tid, "Welterweight", 155, 170)
+
+        reg = _valid_registration()
+        reg["email"] = "boundary@example.com"
+        reg["declared_weight"] = 155.0
+        resp = client.post(f"/api/tournaments/{tid}/registrations", json=reg)
+        assert resp.status_code == 200
+        assert resp.json()["division_id"] == light_id
+
+    def test_weight_just_above_boundary_assigned_higher_division(self, client, admin_token):
+        """155.1 lbs is in Welterweight (lower bound is exclusive)."""
+        tid = _create_tournament(client, admin_token)
+        _create_division(client, admin_token, tid, "Lightweight", 125, 155)
+        welter_id = _create_division(client, admin_token, tid, "Welterweight", 155, 170)
+
+        reg = _valid_registration()
+        reg["email"] = "just-over@example.com"
+        reg["declared_weight"] = 155.1
+        resp = client.post(f"/api/tournaments/{tid}/registrations", json=reg)
+        assert resp.status_code == 200
+        assert resp.json()["division_id"] == welter_id
+
+    def test_weight_just_below_boundary_assigned_lower_division(self, client, admin_token):
+        """154.9 lbs is still Lightweight."""
+        tid = _create_tournament(client, admin_token)
+        light_id = _create_division(client, admin_token, tid, "Lightweight", 125, 155)
+        _create_division(client, admin_token, tid, "Welterweight", 155, 170)
+
+        reg = _valid_registration()
+        reg["email"] = "just-under@example.com"
+        reg["declared_weight"] = 154.9
+        resp = client.post(f"/api/tournaments/{tid}/registrations", json=reg)
+        assert resp.status_code == 200
+        assert resp.json()["division_id"] == light_id
+
+    def test_open_top_division_matches_anyone_above_min(self, client, admin_token):
+        tid = _create_tournament(client, admin_token)
+        heavy_id = _create_division(client, admin_token, tid, "Heavyweight", 205, None)
+
+        reg = _valid_registration()
+        reg["email"] = "heavy@example.com"
+        reg["declared_weight"] = 280.0
+        resp = client.post(f"/api/tournaments/{tid}/registrations", json=reg)
+        assert resp.status_code == 200
+        assert resp.json()["division_id"] == heavy_id
+
+
+class TestBracketGenerationGroupsByDivision:
+    """End-to-end: registrations -> approval auto-creates competitor in the
+    auto-assigned division -> bracket generation groups them correctly."""
+
+    def test_auto_assigned_competitors_in_correct_brackets(self, client, admin_token):
+        tid = _create_tournament(client, admin_token)
+        light_id = _create_division(client, admin_token, tid, "Lightweight", 125, 155)
+        welter_id = _create_division(client, admin_token, tid, "Welterweight", 155, 170)
+
+        # Two lightweights, two welterweights — none pick a division.
+        weights = [
+            ("a@x.com", 140.0, "A", light_id),
+            ("b@x.com", 150.0, "B", light_id),
+            ("c@x.com", 160.0, "C", welter_id),
+            ("d@x.com", 168.0, "D", welter_id),
+        ]
+        for email, w, name, expected_div in weights:
+            r = client.post(f"/api/tournaments/{tid}/registrations", json={
+                "full_name": name, "email": email, "declared_weight": w,
+                "phone": "555", "waiver_agreed": True,
+            })
+            assert r.status_code == 200
+            assert r.json()["division_id"] == expected_div
+            rid = r.json()["id"]
+            client.post(f"/api/tournaments/{tid}/registrations/{rid}/review",
+                        json={"action": "approve"}, headers=auth_header(admin_token))
+
+        light = client.get(f"/api/tournaments/{tid}/divisions/{light_id}/competitors").json()
+        welter = client.get(f"/api/tournaments/{tid}/divisions/{welter_id}/competitors").json()
+        assert {c["full_name"] for c in light} == {"A", "B"}
+        assert {c["full_name"] for c in welter} == {"C", "D"}
+
+        # Generate brackets per division and confirm each pulls only its own competitors.
+        for div_id, expected in [(light_id, {"A", "B"}), (welter_id, {"C", "D"})]:
+            bracket = client.post(
+                f"/api/tournaments/{tid}/divisions/{div_id}/bracket",
+                json={"seeding": "random"}, headers=auth_header(admin_token),
+            ).json()
+            names = {m["competitor1_name"] for m in bracket if m["competitor1_name"]} | \
+                    {m["competitor2_name"] for m in bracket if m["competitor2_name"]}
+            assert names == expected
 
 
 class TestAdminListRegistrations:

--- a/kickboxing-tournament/backend/migrate_kg_to_lbs.py
+++ b/kickboxing-tournament/backend/migrate_kg_to_lbs.py
@@ -1,0 +1,84 @@
+"""One-time migration: convert legacy kg-based weight data to pounds.
+
+Use this only if your database was populated when the system stored weights
+in kilograms. The script:
+
+  - Renames `tournaments.weighin_tolerance_kg` -> `weighin_tolerance_lbs`
+    and multiplies stored values by 2.2046226218.
+  - Multiplies `divisions.weight_class_min` and `weight_class_max` by 2.2046226218.
+  - Multiplies `competitors.declared_weight` and `registrations.declared_weight`
+    by 2.2046226218.
+  - Rewrites `tournaments.weight_presets` JSON, renaming `min_kg`/`max_kg`
+    to `min_lbs`/`max_lbs` and converting values.
+
+Idempotent guard: if `weighin_tolerance_lbs` already exists, the script aborts.
+
+Usage:
+  python migrate_kg_to_lbs.py
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from sqlalchemy import inspect, text
+from app.database import engine
+from app.services.divisions import KG_TO_LBS
+
+
+def _round1(v):
+    return round(v * KG_TO_LBS, 1) if v is not None else None
+
+
+def main():
+    insp = inspect(engine)
+    cols = {c["name"] for c in insp.get_columns("tournaments")}
+    if "weighin_tolerance_lbs" in cols and "weighin_tolerance_kg" not in cols:
+        print("Already migrated; nothing to do.")
+        return
+
+    with engine.begin() as conn:
+        if "weighin_tolerance_kg" in cols:
+            # Rename + convert.
+            conn.execute(text(
+                "ALTER TABLE tournaments RENAME COLUMN weighin_tolerance_kg TO weighin_tolerance_lbs"
+            ))
+            conn.execute(text(
+                "UPDATE tournaments SET weighin_tolerance_lbs = weighin_tolerance_lbs * :f"
+            ), {"f": KG_TO_LBS})
+
+        # Convert division thresholds.
+        for sql in [
+            "UPDATE divisions SET weight_class_min = weight_class_min * :f WHERE weight_class_min IS NOT NULL",
+            "UPDATE divisions SET weight_class_max = weight_class_max * :f WHERE weight_class_max IS NOT NULL",
+            "UPDATE competitors SET declared_weight = declared_weight * :f WHERE declared_weight IS NOT NULL",
+            "UPDATE registrations SET declared_weight = declared_weight * :f WHERE declared_weight IS NOT NULL",
+        ]:
+            conn.execute(text(sql), {"f": KG_TO_LBS})
+
+        # Rewrite weight_presets JSON, key-by-key.
+        rows = conn.execute(text("SELECT id, weight_presets FROM tournaments")).fetchall()
+        import json
+        for row in rows:
+            tid, presets = row[0], row[1]
+            if not presets:
+                continue
+            data = presets if isinstance(presets, list) else json.loads(presets)
+            new_presets = []
+            for p in data:
+                new_presets.append({
+                    "name": p.get("name"),
+                    "min_lbs": _round1(p.get("min_kg")) if "min_kg" in p else p.get("min_lbs"),
+                    "max_lbs": _round1(p.get("max_kg")) if "max_kg" in p else p.get("max_lbs"),
+                })
+            conn.execute(
+                text("UPDATE tournaments SET weight_presets = :v WHERE id = :id"),
+                {"v": json.dumps(new_presets), "id": tid},
+            )
+
+    print("Migration complete: kg values converted to lbs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/kickboxing-tournament/backend/seed_data.py
+++ b/kickboxing-tournament/backend/seed_data.py
@@ -30,51 +30,51 @@ def seed():
         bout_duration_minutes=3,
         break_duration_minutes=2,
         buffer_minutes=1,
-        weighin_tolerance_kg=0.5,
+        weighin_tolerance_lbs=1.1,
         substitution_cutoff_round=1,
         no_show_policy=NoShowPolicy.WALKOVER,
         weight_presets=[
-            {"name": "Flyweight", "min_kg": None, "max_kg": 57},
-            {"name": "Lightweight", "min_kg": 57, "max_kg": 70},
-            {"name": "Middleweight", "min_kg": 70, "max_kg": 84},
-            {"name": "Heavyweight", "min_kg": 84, "max_kg": None},
+            {"name": "Flyweight", "min_lbs": None, "max_lbs": 125},
+            {"name": "Lightweight", "min_lbs": 125, "max_lbs": 155},
+            {"name": "Middleweight", "min_lbs": 155, "max_lbs": 185},
+            {"name": "Heavyweight", "min_lbs": 185, "max_lbs": None},
         ],
     )
     db.add(t)
     db.flush()
 
-    # Create divisions
+    # Create divisions (weight_class_* are pounds).
     divisions_data = [
-        {"name": "Men's Lightweight", "weight_class_min": 57, "weight_class_max": 70,
+        {"name": "Men's Lightweight", "weight_class_min": 125, "weight_class_max": 155,
          "gender": "male", "experience_level": "open"},
-        {"name": "Men's Middleweight", "weight_class_min": 70, "weight_class_max": 84,
+        {"name": "Men's Middleweight", "weight_class_min": 155, "weight_class_max": 185,
          "gender": "male", "experience_level": "open"},
-        {"name": "Women's Lightweight", "weight_class_min": 52, "weight_class_max": 65,
+        {"name": "Women's Lightweight", "weight_class_min": 115, "weight_class_max": 145,
          "gender": "female", "experience_level": "open"},
     ]
 
     competitors_data = {
         "Men's Lightweight": [
-            {"full_name": "Alex Rivera", "declared_weight": 68.5, "gym_team": "Iron Fist MMA"},
-            {"full_name": "Jordan Chen", "declared_weight": 69.0, "gym_team": "Tiger Muay Thai"},
-            {"full_name": "Marcus Williams", "declared_weight": 67.8, "gym_team": "Hammer House"},
-            {"full_name": "Dmitri Volkov", "declared_weight": 69.5, "gym_team": "Red Corner"},
-            {"full_name": "Kai Tanaka", "declared_weight": 68.0, "gym_team": "Rising Sun Dojo"},
-            {"full_name": "Luis Gutierrez", "declared_weight": 69.2, "gym_team": "Iron Fist MMA"},
-            {"full_name": "Tyler Morrison", "declared_weight": 67.5, "gym_team": "Knockout Kings"},
+            {"full_name": "Alex Rivera", "declared_weight": 151.0, "gym_team": "Iron Fist MMA"},
+            {"full_name": "Jordan Chen", "declared_weight": 152.0, "gym_team": "Tiger Muay Thai"},
+            {"full_name": "Marcus Williams", "declared_weight": 149.5, "gym_team": "Hammer House"},
+            {"full_name": "Dmitri Volkov", "declared_weight": 153.0, "gym_team": "Red Corner"},
+            {"full_name": "Kai Tanaka", "declared_weight": 150.0, "gym_team": "Rising Sun Dojo"},
+            {"full_name": "Luis Gutierrez", "declared_weight": 152.5, "gym_team": "Iron Fist MMA"},
+            {"full_name": "Tyler Morrison", "declared_weight": 148.5, "gym_team": "Knockout Kings"},
         ],
         "Men's Middleweight": [
-            {"full_name": "James Okafor", "declared_weight": 82.0, "gym_team": "Power Strike"},
-            {"full_name": "Ryan Thompson", "declared_weight": 81.5, "gym_team": "Hammer House"},
-            {"full_name": "Ahmed Hassan", "declared_weight": 83.0, "gym_team": "Red Corner"},
-            {"full_name": "Viktor Petrov", "declared_weight": 82.5, "gym_team": "Eastern Block"},
-            {"full_name": "Daniel Park", "declared_weight": 80.0, "gym_team": "Tiger Muay Thai"},
+            {"full_name": "James Okafor", "declared_weight": 181.0, "gym_team": "Power Strike"},
+            {"full_name": "Ryan Thompson", "declared_weight": 179.5, "gym_team": "Hammer House"},
+            {"full_name": "Ahmed Hassan", "declared_weight": 183.0, "gym_team": "Red Corner"},
+            {"full_name": "Viktor Petrov", "declared_weight": 182.0, "gym_team": "Eastern Block"},
+            {"full_name": "Daniel Park", "declared_weight": 176.5, "gym_team": "Tiger Muay Thai"},
         ],
         "Women's Lightweight": [
-            {"full_name": "Sarah Mitchell", "declared_weight": 63.0, "gym_team": "Iron Fist MMA"},
-            {"full_name": "Yuki Nakamura", "declared_weight": 62.5, "gym_team": "Rising Sun Dojo"},
-            {"full_name": "Elena Kowalski", "declared_weight": 64.0, "gym_team": "Knockout Kings"},
-            {"full_name": "Priya Sharma", "declared_weight": 61.5, "gym_team": "Tiger Muay Thai"},
+            {"full_name": "Sarah Mitchell", "declared_weight": 139.0, "gym_team": "Iron Fist MMA"},
+            {"full_name": "Yuki Nakamura", "declared_weight": 137.5, "gym_team": "Rising Sun Dojo"},
+            {"full_name": "Elena Kowalski", "declared_weight": 141.0, "gym_team": "Knockout Kings"},
+            {"full_name": "Priya Sharma", "declared_weight": 135.5, "gym_team": "Tiger Muay Thai"},
         ],
     }
 

--- a/kickboxing-tournament/frontend/src/components/MatchActions.jsx
+++ b/kickboxing-tournament/frontend/src/components/MatchActions.jsx
@@ -47,7 +47,7 @@ export default function MatchActions({ match, tid, did, isAdmin, isStaff,
           if (!subName.trim()) { setError('Substitute name is required.'); return; }
           await api.substitution(tid, did, match.id, parseInt(targetCompetitor), {
             full_name: subName,
-            declared_weight: subWeight ? Math.round(parseFloat(subWeight) * 0.453592 * 10) / 10 : null,
+            declared_weight: subWeight ? Math.round(parseFloat(subWeight) * 10) / 10 : null,
             gym_team: subGym || null,
           }, reason);
           setSuccess('Substitution complete.');

--- a/kickboxing-tournament/frontend/src/pages/DivisionView.jsx
+++ b/kickboxing-tournament/frontend/src/pages/DivisionView.jsx
@@ -65,7 +65,7 @@ export default function DivisionView({ isAdmin, isStaff }) {
           <Link to={`/tournament/${tid}`} className="text-sm text-light">&larr; Back to Tournament</Link>
           <h2>{division.name}</h2>
           <p className="text-sm text-light">
-            {division.weight_class_min ? Math.round(division.weight_class_min * 2.20462) : '?'}-{division.weight_class_max ? Math.round(division.weight_class_max * 2.20462) : '?'} lbs
+            {division.weight_class_min ? Math.round(division.weight_class_min) : '?'}-{division.weight_class_max ? Math.round(division.weight_class_max) : '?'} lbs
             {division.gender ? ` | ${division.gender}` : ''}
             &middot; {competitors.filter(c => c.status === 'active').length} active competitor(s)
           </p>
@@ -144,7 +144,7 @@ function CompetitorsTab({ tid, did, competitors, isAdmin, division, onRefresh,
       const weightLbs = form.declared_weight ? parseFloat(form.declared_weight) : null;
       await api.createCompetitor(tid, did, {
         full_name: form.full_name,
-        declared_weight: weightLbs ? Math.round(weightLbs * 0.453592 * 10) / 10 : null,
+        declared_weight: weightLbs ? Math.round(weightLbs * 10) / 10 : null,
         gym_team: form.gym_team || null,
         waiver_signed: true,
       });
@@ -205,7 +205,7 @@ function CompetitorsTab({ tid, did, competitors, isAdmin, division, onRefresh,
             {competitors.map(c => (
               <tr key={c.id}>
                 <td>{c.full_name}</td>
-                <td>{c.declared_weight ? `${Math.round(c.declared_weight * 2.20462)} lbs` : '-'}</td>
+                <td>{c.declared_weight ? `${Math.round(c.declared_weight)} lbs` : '-'}</td>
                 <td>{c.gym_team || '-'}</td>
                 <td>{c.seed || '-'}</td>
                 <td><span className={`badge badge-${c.status}`}>{c.status}</span></td>

--- a/kickboxing-tournament/frontend/src/pages/RegisterPage.jsx
+++ b/kickboxing-tournament/frontend/src/pages/RegisterPage.jsx
@@ -9,7 +9,6 @@ import api from '../utils/api';
 export default function RegisterPage() {
   const { id } = useParams();
   const [tournament, setTournament] = useState(null);
-  const [divisions, setDivisions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -23,7 +22,6 @@ export default function RegisterPage() {
   const [form, setForm] = useState({
     full_name: '',
     email: '',
-    division_id: '',
     declared_weight: '',
     gym_team: '',
     phone: '',
@@ -35,15 +33,8 @@ export default function RegisterPage() {
   useEffect(() => {
     async function load() {
       try {
-        const [t, d] = await Promise.all([
-          api.getTournament(id),
-          api.getDivisions(id),
-        ]);
+        const t = await api.getTournament(id);
         setTournament(t);
-        setDivisions(d);
-        if (d.length > 0) {
-          setForm(f => ({ ...f, division_id: String(d[0].id) }));
-        }
       } catch (e) {
         setError(e.message);
       } finally {
@@ -61,12 +52,16 @@ export default function RegisterPage() {
     setSuccess('');
     setSubmitting(true);
     try {
-      const weightLbs = form.declared_weight ? parseFloat(form.declared_weight) : null;
+      const weightLbs = parseFloat(form.declared_weight);
+      if (!weightLbs || weightLbs <= 0) {
+        setError('Please enter a valid weight in pounds.');
+        setSubmitting(false);
+        return;
+      }
       const payload = {
         full_name: form.full_name,
         email: form.email,
-        division_id: parseInt(form.division_id),
-        declared_weight: weightLbs ? Math.round(weightLbs * 0.453592 * 10) / 10 : null,
+        declared_weight: Math.round(weightLbs * 10) / 10,
         gym_team: form.gym_team || null,
         phone: form.phone,
         age: form.age ? parseInt(form.age) : null,
@@ -75,11 +70,11 @@ export default function RegisterPage() {
       };
       await api.submitRegistration(id, payload);
       setSuccess(
-        'Registration submitted successfully! Your registration is pending review by the tournament organizer. ' +
-        'You will be added to the bracket once approved.'
+        'Registration submitted successfully! Your division has been auto-assigned ' +
+        'based on your weight. The tournament organizer will review and approve your registration.'
       );
       setForm({
-        full_name: '', email: '', division_id: divisions[0]?.id || '',
+        full_name: '', email: '',
         declared_weight: '', gym_team: '', phone: '', age: '',
         experience_level: '', waiver_agreed: false,
       });
@@ -181,25 +176,13 @@ export default function RegisterPage() {
                 placeholder="your@email.com" maxLength={200} />
               <span className="text-sm text-light">Used for registration confirmation and duplicate prevention</span>
             </div>
-            <div className="form-group">
-              <label>Division *</label>
-              <select required value={form.division_id} onChange={e => set('division_id', e.target.value)}>
-                <option value="" disabled>Select a division</option>
-                {divisions.map(d => (
-                  <option key={d.id} value={String(d.id)}>
-                    {d.name}
-                    {d.weight_class_min && d.weight_class_max ? ` (${Math.round(d.weight_class_min * 2.20462)}-${Math.round(d.weight_class_max * 2.20462)} lbs)` : ''}
-                    {d.gender ? ` - ${d.gender}` : ''}
-                  </option>
-                ))}
-              </select>
-            </div>
             <div className="form-row">
               <div className="form-group">
-                <label>Declared Weight (lbs)</label>
-                <input type="number" step="0.1" value={form.declared_weight}
+                <label>Weight (lbs) *</label>
+                <input type="number" step="0.1" min="0" required value={form.declared_weight}
                   onChange={e => set('declared_weight', e.target.value)}
-                  placeholder="e.g., 155" />
+                  placeholder="Enter weight in pounds" />
+                <span className="text-sm text-light">Your division will be auto-assigned based on this weight.</span>
               </div>
               <div className="form-group">
                 <label>Gym / Team</label>

--- a/kickboxing-tournament/frontend/src/pages/TournamentList.jsx
+++ b/kickboxing-tournament/frontend/src/pages/TournamentList.jsx
@@ -84,10 +84,9 @@ function CreateTournamentModal({ onClose, onCreated }) {
     e.preventDefault();
     setError('');
     try {
-      const { weighin_tolerance_lbs, ...rest } = form;
       const t = await api.createTournament({
-        ...rest,
-        weighin_tolerance_kg: Math.round(weighin_tolerance_lbs * 0.453592 * 10) / 10,
+        ...form,
+        weighin_tolerance_lbs: Math.round(form.weighin_tolerance_lbs * 10) / 10,
       });
       onCreated(t);
     } catch (e) {

--- a/kickboxing-tournament/frontend/src/pages/TournamentView.jsx
+++ b/kickboxing-tournament/frontend/src/pages/TournamentView.jsx
@@ -101,8 +101,8 @@ export default function TournamentView({ isAdmin, isStaff }) {
                   <h3>{d.name}</h3>
                   <p className="text-sm text-light">
                     {d.weight_class_min && d.weight_class_max
-                      ? `${Math.round(d.weight_class_min * 2.20462)}-${Math.round(d.weight_class_max * 2.20462)} lbs`
-                      : d.weight_class_max ? `Up to ${Math.round(d.weight_class_max * 2.20462)} lbs` : d.weight_class_min ? `${Math.round(d.weight_class_min * 2.20462)}+ lbs` : ''}
+                      ? `${Math.round(d.weight_class_min)}-${Math.round(d.weight_class_max)} lbs`
+                      : d.weight_class_max ? `Up to ${Math.round(d.weight_class_max)} lbs` : d.weight_class_min ? `${Math.round(d.weight_class_min)}+ lbs` : ''}
                     {d.gender ? ` | ${d.gender}` : ''}
                     {d.experience_level ? ` | ${d.experience_level}` : ''}
                   </p>
@@ -185,8 +185,8 @@ function AddDivisionModal({ tournamentId, onClose, onCreated }) {
     try {
       const data = {
         ...form,
-        weight_class_min: form.weight_class_min ? Math.round(parseFloat(form.weight_class_min) * 0.453592 * 10) / 10 : null,
-        weight_class_max: form.weight_class_max ? Math.round(parseFloat(form.weight_class_max) * 0.453592 * 10) / 10 : null,
+        weight_class_min: form.weight_class_min ? Math.round(parseFloat(form.weight_class_min) * 10) / 10 : null,
+        weight_class_max: form.weight_class_max ? Math.round(parseFloat(form.weight_class_max) * 10) / 10 : null,
         gender: form.gender || null,
         age_group: form.age_group || null,
         experience_level: form.experience_level || null,
@@ -399,7 +399,7 @@ function RegistrationsTab({ tournamentId, tournament, onRefresh }) {
                   <td>{r.full_name}</td>
                   <td className="text-sm">{r.email}</td>
                   <td>{r.division_name || `Division #${r.division_id}`}</td>
-                  <td>{r.declared_weight ? `${Math.round(r.declared_weight * 2.20462)} lbs` : '-'}</td>
+                  <td>{r.declared_weight ? `${Math.round(r.declared_weight)} lbs` : '-'}</td>
                   <td>{r.gym_team || '-'}</td>
                   <td><span className={`badge badge-${r.status}`}>{r.status}</span></td>
                   <td className="text-sm">{r.created_at ? new Date(r.created_at).toLocaleString() : ''}</td>
@@ -441,7 +441,7 @@ function SettingsTab({ tournament, onSaved }) {
     bout_duration_minutes: tournament.bout_duration_minutes,
     break_duration_minutes: tournament.break_duration_minutes,
     buffer_minutes: tournament.buffer_minutes,
-    weighin_tolerance_lbs: Math.round(tournament.weighin_tolerance_kg * 2.20462 * 10) / 10,
+    weighin_tolerance_lbs: tournament.weighin_tolerance_lbs,
     substitution_cutoff_round: tournament.substitution_cutoff_round,
     no_show_policy: tournament.no_show_policy,
     registration_open: tournament.registration_open,
@@ -458,10 +458,9 @@ function SettingsTab({ tournament, onSaved }) {
     setSuccess('');
     setSaving(true);
     try {
-      const { weighin_tolerance_lbs, ...rest } = form;
       await api.updateTournament(tournament.id, {
-        ...rest,
-        weighin_tolerance_kg: Math.round(weighin_tolerance_lbs * 0.453592 * 10) / 10,
+        ...form,
+        weighin_tolerance_lbs: Math.round(form.weighin_tolerance_lbs * 10) / 10,
       });
       setSuccess('Settings saved.');
       onSaved();


### PR DESCRIPTION
## Summary
This PR converts the entire tournament management system from kilogram-based weight tracking to pounds (lbs). All weight thresholds, division boundaries, competitor weights, and tolerance values are now stored and compared in pounds.

## Key Changes

**Database & Models**
- Renamed `Tournament.weighin_tolerance_kg` → `weighin_tolerance_lbs` (default 1.1 lbs ≈ 0.5 kg)
- Updated `WeightPreset` schema fields: `min_kg`/`max_kg` → `min_lbs`/`max_lbs`
- All weight-related columns (`Division.weight_class_min/max`, `Competitor.declared_weight`, `Registration.declared_weight`) now store values in pounds

**Division Auto-Assignment**
- Created new `app/services/divisions.py` module with:
  - `assign_division()` function that auto-assigns competitors to divisions based on declared weight in pounds
  - Boundary convention: divisions use open-low / closed-high ranges (e.g., 125 < weight ≤ 155)
  - `DEFAULT_WEIGHT_PRESETS_LBS` with MMA-style weight classes in pounds (Strawweight through Heavyweight)
- Updated registration flow to auto-assign division instead of requiring manual selection

**Registration Form**
- Removed manual division selection dropdown from frontend
- Made `declared_weight` (in pounds) a required field
- Weight is now used to automatically assign the appropriate division
- Updated success message to reflect auto-assignment

**Migration Support**
- Added `migrate_kg_to_lbs.py` one-time migration script that:
  - Converts all existing kg values to lbs using factor 2.2046226218
  - Updates tournament weight presets JSON
  - Includes idempotency guard to prevent re-running

**Tests**
- Updated all test fixtures to use pound values
- Added comprehensive `TestDivisionAutoAssignment` test class covering:
  - Weight-to-division matching
  - Boundary conditions (upper bound inclusive, lower bound exclusive)
  - Open-ended divisions (no max weight)
- Added `TestBracketGenerationGroupsByDivision` end-to-end test verifying auto-assigned competitors are grouped correctly in brackets

**Frontend Updates**
- Removed kg-to-lbs conversion logic from forms (now all inputs/outputs are in lbs)
- Updated division weight display to show pounds directly without conversion
- Simplified tournament creation and division management forms

## Implementation Details
- The boundary convention (lower exclusive, upper inclusive) ensures no gaps or overlaps between adjacent divisions
- Division auto-assignment is deterministic and re-runnable (used both at registration submission and approval)
- All weight comparisons now use consistent pound-based logic
- Seed data updated with realistic pound-based weights for demo competitors

https://claude.ai/code/session_019nAmcqh8pLWmkWV2WmssJ4